### PR TITLE
Alternate advanced compilation fix

### DIFF
--- a/src/parse_names/core.cljs
+++ b/src/parse_names/core.cljs
@@ -3,10 +3,10 @@
 
 (defn parse-name [name]
   (let [name-obj (v/parse name)]
-    (->> {:first-name (.-firstName name-obj)
-          :last-name (.-lastName name-obj)
-          :salutation (.-salutation name-obj)
-          :suffix (.-suffix name-obj)
-          :initials (.-initials name-obj)}
+    (->> {:first-name (aget name-obj "firstName")
+          :last-name (aget name-obj "lastName")
+          :salutation (aget name-obj "salutation")
+          :suffix (aget name-obj "suffix")
+          :initials (aget name-obj "initials")}
          (filter (fn [[k v]] (not (empty? v))))
          (into {}))))

--- a/src/parse_names/vendor.js
+++ b/src/parse_names/vendor.js
@@ -162,10 +162,10 @@ parse_names.vendor.parse = function (fullastName) {
     }
     // return the various parts in an array
     return {
-	salutation: salutation || "",
-	firstName: firstName.trim(),
-	initials: initials.trim(),
-	lastName: lastName.trim(),
-	suffix: suffix || ""
+	"salutation": salutation || "",
+	"firstName": firstName.trim(),
+	"initials": initials.trim(),
+	"lastName": lastName.trim(),
+	"suffix": suffix || ""
     };
 };


### PR DESCRIPTION
Hey @bensu apologies for the churn, but on second thought I think it's safer to use string keys in the map and refer to the properties as strings on the clojurescript side too.  Thoughts?
